### PR TITLE
Fix example code in documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+.idea/
+

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This image is based on the official [Neo4j][__link1] image. The default user is 
 use testcontainers::clients::Cli;
 use neo4j_testcontainers::Neo4j;
 
-let cli = Cli::default();
+let docker = Cli::default();
 let container = docker.run(Neo4j::default());
 let uri = Neo4j::uri_ipv4(&container);
 let auth_user = container.image().user();

--- a/doc/lib.md
+++ b/doc/lib.md
@@ -10,7 +10,7 @@ The default version is `5`.
 use testcontainers::clients::Cli;
 use neo4j_testcontainers::Neo4j;
 
-let cli = Cli::default();
+let docker = Cli::default();
 let container = docker.run(Neo4j::default());
 let uri = Neo4j::uri_ipv4(&container);
 let auth_user = container.image().user();


### PR DESCRIPTION
The documentation had an "compile error". Also duplicated the change into the README.

(Unrelated change: add `.idea` to the _.gitignore_ for lazy me)