### PR TITLE
Add function to retrieve http connection uri.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ use neo4j_testcontainers::Neo4j;
 
 let cli = Cli::default();
 let container = docker.run(Neo4j::default());
-let uri = Neo4j::uri_ipv4(&container);
+let uri = Neo4j::bolt_uri_ipv4(&container);
 let auth_user = container.image().user();
 let auth_pass = container.image().pass();
 // connect to Neo4j with the uri, user and pass

--- a/doc/lib.md
+++ b/doc/lib.md
@@ -12,7 +12,7 @@ use neo4j_testcontainers::Neo4j;
 
 let cli = Cli::default();
 let container = docker.run(Neo4j::default());
-let uri = Neo4j::uri_ipv4(&container);
+let uri = Neo4j::bolt_uri_ipv4(&container);
 let auth_user = container.image().user();
 let auth_pass = container.image().pass();
 // connect to Neo4j with the uri, user and pass

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,10 +132,7 @@ impl Neo4j {
     }
 
     /// Return the connection URI to connect to the Neo4j server via Bolt over IPv4.
-    #[deprecated(
-        since = "0.2.0",
-        note = "Use `bolt_uri_ipv4()` instead."
-    )]
+    #[deprecated(since = "0.2.0", note = "Use `bolt_uri_ipv4()` instead.")]
     #[must_use]
     pub fn uri_ipv4(container: &Container<'_, Self>) -> String {
         let bolt_port = container
@@ -146,10 +143,7 @@ impl Neo4j {
     }
 
     /// Return the connection URI to connect to the Neo4j server via Bolt over IPv6.
-    #[deprecated(
-        since = "0.2.0",
-        note = "Use `bolt_uri_ipv6()` instead."
-    )]
+    #[deprecated(since = "0.2.0", note = "Use `bolt_uri_ipv6()` instead.")]
     #[must_use]
     pub fn uri_ipv6(container: &Container<'_, Self>) -> String {
         let bolt_port = container

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,11 @@ impl Neo4j {
         &self.pass
     }
 
-    // Return the connection URI to connect to the Neo4j server over IPv4.
+    /// Return the connection URI to connect to the Neo4j server via Bolt over IPv4.
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use `bolt_uri_ipv4()` instead."
+    )]
     #[must_use]
     pub fn uri_ipv4(container: &Container<'_, Self>) -> String {
         let bolt_port = container
@@ -141,7 +145,11 @@ impl Neo4j {
         format!("bolt://127.0.0.1:{}", bolt_port)
     }
 
-    // Return the connection URI to connect to the Neo4j server over IPv6.
+    /// Return the connection URI to connect to the Neo4j server via Bolt over IPv6.
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use `bolt_uri_ipv6()` instead."
+    )]
     #[must_use]
     pub fn uri_ipv6(container: &Container<'_, Self>) -> String {
         let bolt_port = container
@@ -149,6 +157,46 @@ impl Neo4j {
             .map_to_host_port_ipv6(7687)
             .expect("Image exposes 7687 by default");
         format!("bolt://[::1]:{}", bolt_port)
+    }
+
+    /// Return the connection URI to connect to the Neo4j server via Bolt over IPv4.
+    #[must_use]
+    pub fn bolt_uri_ipv4(container: &Container<'_, Self>) -> String {
+        let bolt_port = container
+            .ports()
+            .map_to_host_port_ipv4(7687)
+            .expect("Image exposes 7687 by default");
+        format!("bolt://127.0.0.1:{}", bolt_port)
+    }
+
+    /// Return the connection URI to connect to the Neo4j server via Bolt over IPv6.
+    #[must_use]
+    pub fn bolt_uri_ipv6(container: &Container<'_, Self>) -> String {
+        let bolt_port = container
+            .ports()
+            .map_to_host_port_ipv6(7687)
+            .expect("Image exposes 7687 by default");
+        format!("bolt://[::1]:{}", bolt_port)
+    }
+
+    /// Return the connection URI to connect to the Neo4j server via HTTP over IPv4.
+    #[must_use]
+    pub fn http_uri_ipv4(container: &Container<'_, Self>) -> String {
+        let http_port = container
+            .ports()
+            .map_to_host_port_ipv4(7474)
+            .expect("Image exposes 7474 by default");
+        format!("http://127.0.0.1:{}", http_port)
+    }
+
+    /// Return the connection URI to connect to the Neo4j server via HTTP over IPv6.
+    #[must_use]
+    pub fn http_uri_ipv6(container: &Container<'_, Self>) -> String {
+        let http_port = container
+            .ports()
+            .map_to_host_port_ipv6(7474)
+            .expect("Image exposes 7474 by default");
+        format!("http://[::1]:{}", http_port)
     }
 }
 


### PR DESCRIPTION
Also deprecate existing uri_ip4/ip6 functions
to be more explicit which uri gets returned.

One could argue that the uris are only urls,
but let's keep the term uri for now.